### PR TITLE
Feat/ruleresult webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ APPLICATION_NAME=Hygie
 NODE_ENV=development
 VERBOSE_LOGGER=true
 ANALYTICS_ID=UA-XXXXX
-DEFAULT_CONFIGURATION_FILE=https://raw.githubusercontent.com/DX-DeveloperExperience/git-webhooks-configuration/master/.rulesrc
+DEFAULT_CONFIGURATION_FILE=https://raw.githubusercontent.com/DX-DeveloperExperience/hygie-configuration/master/.rulesrc
 ENCRYPTION_KEY=XXXX
 PORT=3000

--- a/.hygie/.rulesrc
+++ b/.hygie/.rulesrc
@@ -15,7 +15,7 @@ rules:
     onSuccess:
       - callback: CreatePullRequestRunnable
         args:
-          title: 'WIP: {{data.branch}}'
+          title: 'WIP: {{data.branchName}}'
           description: 'Work in Progress Pull Request'
           draft: true
 

--- a/docs/post-actions/existingRunnables.md
+++ b/docs/post-actions/existingRunnables.md
@@ -96,7 +96,7 @@ This Post-Action need the following args:
   :::
 - `target`: the target branch _[optional]_.
   ::: tip
-  current branch return by the `data.branch` attribute of the previous `RuleResult`.
+  current branch return by the `data.branchBranch` attribute of the previous `RuleResult`.
   :::
 
 To use the `CreatePullRequestRunnable`, add the `callback` on your `.rulesrc` config file.
@@ -122,7 +122,7 @@ This Post-Action has one optionnal arg:
 
 - `branchName`: the branch to delete _[optional]_.
   ::: tip
-  If no branch name is provide, it will be set to `data.branch` returned by the previous rule.
+  If no branch name is provide, it will be set to `data.branchBranch` returned by the previous rule.
   :::
 
 To use the `DeleteBranchRunnable`, simply add the `callback` on your `.rulesrc` config file.
@@ -152,7 +152,7 @@ This Post-Action need the following args:
   :::
 - branch: the branch on which it will delete the files _[optional]_.
   ::: tip
-  If no branch name is provide, it will be set to `data.branch` returned by the previous rule if exist, `master` otherwise.
+  If no branch name is provide, it will be set to `data.branchBranch` returned by the previous rule if exist, `master` otherwise.
   :::
 
 To use the `DeleteFilesRunnable`, simply add the `callback` on your `.rulesrc` config file.
@@ -236,7 +236,7 @@ To use the `MergePullRequestRunnable`, simply add the `callback` on your `.rules
 onSuccess:
   - callback: MergePullRequestRunnable
     args:
-      commitTitle: 'merging {{data.branch}} PR'
+      commitTitle: 'merging {{data.branchBranch}} PR'
       commitMessage: 'extra informations...'
       sha: 6dcb09b5b57875f334f61aebed695e2e4193db5e
       method: squash

--- a/docs/rules/existingRules.md
+++ b/docs/rules/existingRules.md
@@ -36,11 +36,11 @@ Checks the branch's name according to a regular expression.
     - callback: DeleteBranchRunnable #CAUTION!
     - callback: LoggerRunnable
       args:
-        message: 'Branch {{data.branch}} has been deleted because it does not begin with fix or feature.'
+        message: 'Branch {{data.branchBranch}} has been deleted because it does not begin with fix or feature.'
   onSuccess:
     - callback: CreatePullRequestRunnable
       args:
-        title: 'WIP: {{data.branch}}'
+        title: 'WIP: {{data.branchBranch}}'
         description: 'Work in Progress Pull Request'
 ```
 

--- a/docs/rules/rulesExample.md
+++ b/docs/rules/rulesExample.md
@@ -18,11 +18,11 @@ rules:
     onError:
       - callback: LoggerRunnable
         args:
-          message: 'Branch {{data.branch}} does not begin with fix or feature.'
+          message: 'Branch {{data.branchBranch}} does not begin with fix or feature.'
     onSuccess:
       - callback: CreatePullRequestRunnable
         args:
-          title: 'WIP: {{data.branch}}'
+          title: 'WIP: {{data.branchBranch}}'
           description: 'Work in Progress Pull Request'
 
   # PULL REQUESTS

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "copyfiles": "cpx src/rules/.rulesrc dist/rules && cpx \"src/rules/*.rule.ts\" dist/rules && cpx src/rules/rules.options.ts dist/rules && cpx \"src/runnables/*.runnable.ts\" dist/runnables && cpx \"src/views/*\" dist/views && cpx \"src/public/**/*\" dist/public",
     "build": "rimraf dist && tsc -p tsconfig.build.json && npm run copyfiles",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "prettier-test": "prettier -l \"src/**/*.ts\" \"test/**/*.ts\"",
+    "prettier-test": "prettier -c \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "ts-node --transpile-only -r tsconfig-paths/register src/main.ts",
     "start:dev": "nodemon",
     "start:debug": "nodemon --config nodemon-debug.json",

--- a/src/rules/.rulesrc
+++ b/src/rules/.rulesrc
@@ -15,11 +15,11 @@ rules:
     onError:
       - callback: LoggerRunnable
         args:
-          message: 'Branch {{data.branch}} does not begin with fix or feature.'
+          message: 'Branch {{data.branchBranch}} does not begin with fix or feature.'
     onSuccess:
       - callback: CreatePullRequestRunnable
         args:
-          title: 'WIP: {{data.branch}}'
+          title: 'WIP: {{data.branchBranch}}'
           description: 'Work in Progress Pull Request'
           draft: true
 

--- a/src/rules/branchName.rule.spec.ts
+++ b/src/rules/branchName.rule.spec.ts
@@ -48,7 +48,10 @@ describe('RulesService', () => {
       const result: RuleResult = await branchName.validate(webhook, branchName);
       expect(result.validated).toBe(true);
       expect((result.data as any).branchSplit).toEqual(['features', 'tdd']);
-      expect(JSON.parse(JSON.stringify((result.data as any).matches))).toEqual(['features/tdd', 'features']);
+      expect(JSON.parse(JSON.stringify((result.data as any).matches))).toEqual([
+        'features/tdd',
+        'features',
+      ]);
     });
   });
   describe('branchName Rule', () => {

--- a/src/rules/branchName.rule.spec.ts
+++ b/src/rules/branchName.rule.spec.ts
@@ -47,12 +47,8 @@ describe('RulesService', () => {
 
       const result: RuleResult = await branchName.validate(webhook, branchName);
       expect(result.validated).toBe(true);
-
-      expect(JSON.parse(JSON.stringify(result.data))).toEqual({
-        branch: 'features/tdd',
-        branchSplit: ['features', 'tdd'],
-        matches: ['features/tdd', 'features'],
-      });
+      expect((result.data as any).branchSplit).toEqual(['features', 'tdd']);
+      expect(JSON.parse(JSON.stringify((result.data as any).matches))).toEqual(['features/tdd', 'features']);
     });
   });
   describe('branchName Rule', () => {
@@ -67,7 +63,6 @@ describe('RulesService', () => {
 
       const result: RuleResult = await branchName.validate(webhook, branchName);
       expect(result.validated).toBe(false);
-      expect((result.data as any).branch).toEqual('testing/tdd');
       expect((result.data as any).branchSplit).toEqual(['testing', 'tdd']);
       expect((result.data as any).matches).toEqual(null);
     });

--- a/src/rules/branchName.rule.ts
+++ b/src/rules/branchName.rule.ts
@@ -49,7 +49,7 @@ export class BranchNameRule extends Rule {
 
     ruleResult.validated = branchRegExp.test(branchName);
 
-    ruleResult.data.branchSplit =  branchName.split('/');
+    ruleResult.data.branchSplit = branchName.split('/');
     ruleResult.data.matches = branchName.match(branchRegExp);
 
     return ruleResult;

--- a/src/rules/branchName.rule.ts
+++ b/src/rules/branchName.rule.ts
@@ -34,10 +34,7 @@ export class BranchNameRule extends Rule {
     ruleConfig: BranchNameRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     const branchName = webhook.getBranchName();
     const branchRegExp = RegExp(ruleConfig.options.regexp);
 
@@ -51,11 +48,9 @@ export class BranchNameRule extends Rule {
     }
 
     ruleResult.validated = branchRegExp.test(branchName);
-    ruleResult.data = {
-      branch: branchName,
-      branchSplit: branchName.split('/'),
-      matches: branchName.match(branchRegExp),
-    };
+
+    ruleResult.data.branchSplit =  branchName.split('/');
+    ruleResult.data.matches = branchName.match(branchRegExp);
 
     return ruleResult;
   }

--- a/src/rules/checkAddedFiles.rule.spec.ts
+++ b/src/rules/checkAddedFiles.rule.spec.ts
@@ -113,7 +113,14 @@ describe('RulesService', () => {
       );
 
       expect(result.validated).toBe(true);
-      expect(result.data.addedFiles).toEqual(['a.md', 'b.md', 'e.md', 'aa.md', 'bb.md', 'ee.md']);
+      expect(result.data.addedFiles).toEqual([
+        'a.md',
+        'b.md',
+        'e.md',
+        'aa.md',
+        'bb.md',
+        'ee.md',
+      ]);
     });
   });
 });

--- a/src/rules/checkAddedFiles.rule.spec.ts
+++ b/src/rules/checkAddedFiles.rule.spec.ts
@@ -77,12 +77,8 @@ describe('RulesService', () => {
         webhook,
         checkAddedFilesRule,
       );
-      const expectedResult = {
-        addedFiles: [],
-        branch: 'test_branch',
-      };
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.addedFiles).toEqual([]);
     });
   });
 
@@ -115,12 +111,9 @@ describe('RulesService', () => {
         webhook,
         checkAddedFilesRule,
       );
-      const expectedResult = {
-        addedFiles: ['a.md', 'b.md', 'e.md', 'aa.md', 'bb.md', 'ee.md'],
-        branch: 'test_branch',
-      };
+
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.addedFiles).toEqual(['a.md', 'b.md', 'e.md', 'aa.md', 'bb.md', 'ee.md']);
     });
   });
 });

--- a/src/rules/checkAddedFiles.rule.ts
+++ b/src/rules/checkAddedFiles.rule.ts
@@ -35,10 +35,7 @@ export class CheckAddedFilesRule extends Rule {
     ruleConfig: CheckAddedFilesRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     const commits: WebhookCommit[] = webhook.getAllCommits();
     const addedRegExp = RegExp(ruleConfig.options.regexp);
 

--- a/src/rules/checkAddedFiles.rule.ts
+++ b/src/rules/checkAddedFiles.rule.ts
@@ -64,10 +64,7 @@ export class CheckAddedFilesRule extends Rule {
       });
 
     ruleResult.validated = allMatchingAddedFiles.length > 0;
-    ruleResult.data = {
-      addedFiles: allMatchingAddedFiles,
-      branch: webhook.getBranchName(),
-    };
+    ruleResult.data.addedFiles = allMatchingAddedFiles;
 
     return ruleResult;
   }

--- a/src/rules/checkCoverage.rule.spec.ts
+++ b/src/rules/checkCoverage.rule.spec.ts
@@ -110,7 +110,7 @@ describe('RulesService', () => {
         webhook,
         checkCoverageRule,
       );
-      const expectedResult =  [
+      const expectedResult = [
         {
           branch: 'develop',
           coverage_change: -0.2,

--- a/src/rules/checkCoverage.rule.spec.ts
+++ b/src/rules/checkCoverage.rule.spec.ts
@@ -110,23 +110,21 @@ describe('RulesService', () => {
         webhook,
         checkCoverageRule,
       );
-      const expectedResult = {
-        coverage: [
-          {
-            branch: 'develop',
-            coverage_change: -0.2,
-            covered_percent: 77.985285795133,
-          },
-          {
-            branch: 'master',
-            coverage_change: 0.2,
-            covered_percent: 79.985285795133,
-          },
-        ],
-      };
+      const expectedResult =  [
+        {
+          branch: 'develop',
+          coverage_change: -0.2,
+          covered_percent: 77.985285795133,
+        },
+        {
+          branch: 'master',
+          coverage_change: 0.2,
+          covered_percent: 79.985285795133,
+        },
+      ];
 
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.coverage).toEqual(expectedResult);
     });
   });
 
@@ -199,23 +197,21 @@ describe('RulesService', () => {
         webhook,
         checkCoverageRule,
       );
-      const expectedResult = {
-        coverage: [
-          {
-            branch: 'develop',
-            coverage_change: -0.2,
-            covered_percent: 77.985285795133,
-          },
-          {
-            branch: 'master',
-            coverage_change: 0.2,
-            covered_percent: 79.985285795133,
-          },
-        ],
-      };
+      const expectedResult = [
+        {
+          branch: 'develop',
+          coverage_change: -0.2,
+          covered_percent: 77.985285795133,
+        },
+        {
+          branch: 'master',
+          coverage_change: 0.2,
+          covered_percent: 79.985285795133,
+        },
+      ];
 
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.coverage).toEqual(expectedResult);
     });
   });
 
@@ -288,23 +284,21 @@ describe('RulesService', () => {
         webhook,
         checkCoverageRule,
       );
-      const expectedResult = {
-        coverage: [
-          {
-            branch: 'develop',
-            coverage_change: 0.2,
-            covered_percent: 67.985285795133,
-          },
-          {
-            branch: 'master',
-            coverage_change: 0.2,
-            covered_percent: 79.985285795133,
-          },
-        ],
-      };
+      const expectedResult = [
+        {
+          branch: 'develop',
+          coverage_change: 0.2,
+          covered_percent: 67.985285795133,
+        },
+        {
+          branch: 'master',
+          coverage_change: 0.2,
+          covered_percent: 79.985285795133,
+        },
+      ];
 
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.coverage).toEqual(expectedResult);
     });
   });
 });

--- a/src/rules/checkCoverage.rule.ts
+++ b/src/rules/checkCoverage.rule.ts
@@ -40,10 +40,7 @@ export class CheckCoverageRule extends Rule {
     ruleConfig: CheckCoverageRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     ruleResult.data = { coverage: [] };
     let allBranchesPassed: boolean = true;
     let coverageURL: string;

--- a/src/rules/checkIssues.rule.spec.ts
+++ b/src/rules/checkIssues.rule.spec.ts
@@ -64,10 +64,8 @@ describe('RulesService', () => {
       );
       jest.fn().mockReset();
 
-      const expectedResult = {};
-
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.issue.number).toEqual(undefined);
     });
   });
   describe('checkIssues Rule', () => {
@@ -104,10 +102,8 @@ describe('RulesService', () => {
 
       jest.fn().mockReset();
 
-      const expectedResult = { issue: { number: [1, 2, 3] } };
-
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.issue.number).toEqual([1, 2, 3]);
     });
   });
   describe('checkIssues Rule', () => {
@@ -144,10 +140,8 @@ describe('RulesService', () => {
 
       jest.fn().mockReset();
 
-      const expectedResult = { issue: { number: [1, 2, 3] } };
-
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.issue.number).toEqual([1, 2, 3]);
     });
   });
 });

--- a/src/rules/checkIssues.rule.ts
+++ b/src/rules/checkIssues.rule.ts
@@ -81,11 +81,7 @@ export class CheckIssuesRule extends Rule {
     ruleResult.validated = issuesToUpdate.length > 0;
 
     if (ruleResult.validated) {
-      ruleResult.data = {
-        issue: { number: issuesToUpdate },
-      };
-    } else {
-      ruleResult.data = {};
+      ruleResult.data.issue.number = issuesToUpdate;
     }
 
     return ruleResult;

--- a/src/rules/checkIssues.rule.ts
+++ b/src/rules/checkIssues.rule.ts
@@ -40,10 +40,7 @@ export class CheckIssuesRule extends Rule {
     ruleConfig: CheckIssuesRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     this.googleAnalytics
       .event('Rule', 'checkIssues', webhook.getCloneURL())
       .send();

--- a/src/rules/checkPullRequestStatus.rule.spec.ts
+++ b/src/rules/checkPullRequestStatus.rule.spec.ts
@@ -57,14 +57,7 @@ describe('RulesService', () => {
         checkPullRequestStatus,
       );
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual({
-        pullRequest: {
-          description: 'my desc',
-          event: 'closed',
-          number: 22,
-          title: 'my PR for webhook',
-        },
-      });
+      expect(result.data.pullRequest.event).toEqual('closed');
     });
   });
   describe('checkPullRequestStatus Rule', () => {
@@ -77,14 +70,7 @@ describe('RulesService', () => {
         checkPullRequestStatus,
       );
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual({
-        pullRequest: {
-          description: 'my desc',
-          event: 'closed',
-          number: 22,
-          title: 'my PR for webhook',
-        },
-      });
+      expect(result.data.pullRequest.event).toEqual('closed');
     });
   });
 

--- a/src/rules/checkPullRequestStatus.rule.ts
+++ b/src/rules/checkPullRequestStatus.rule.ts
@@ -44,10 +44,7 @@ export class CheckPullRequestStatusRule extends Rule {
     ruleConfig: CheckPullRequestStatusRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     const gitEvent = this.getEvent(webhook.gitEvent);
 
     this.googleAnalytics

--- a/src/rules/checkPullRequestStatus.rule.ts
+++ b/src/rules/checkPullRequestStatus.rule.ts
@@ -59,14 +59,7 @@ export class CheckPullRequestStatusRule extends Rule {
     ruleResult.validated =
       gitEvent === ruleConfig.options.status.toLocaleLowerCase() ? true : false;
 
-    ruleResult.data = {
-      pullRequest: {
-        event: gitEvent,
-        title: webhook.getPullRequestTitle(),
-        number: webhook.getPullRequestNumber(),
-        description: webhook.getPullRequestDescription(),
-      },
-    };
+    ruleResult.data.pullRequest.event = gitEvent;
 
     return ruleResult;
   }

--- a/src/rules/checkPullRequests.rule.spec.ts
+++ b/src/rules/checkPullRequests.rule.spec.ts
@@ -64,10 +64,8 @@ describe('RulesService', () => {
       );
       jest.fn().mockReset();
 
-      const expectedResult = {};
-
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.pullRequest.number).toEqual(undefined);
     });
   });
   describe('CheckPullRequests Rule', () => {
@@ -106,10 +104,8 @@ describe('RulesService', () => {
 
       jest.fn().mockReset();
 
-      const expectedResult = { pullRequest: { number: [1, 2, 3] } };
-
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.pullRequest.number).toEqual([1, 2, 3]);
     });
   });
   describe('CheckPullRequests Rule', () => {
@@ -148,10 +144,8 @@ describe('RulesService', () => {
 
       jest.fn().mockReset();
 
-      const expectedResult = { pullRequest: { number: [1, 2, 3] } };
-
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.pullRequest.number).toEqual([1, 2, 3]);
     });
   });
 });

--- a/src/rules/checkPullRequests.rule.ts
+++ b/src/rules/checkPullRequests.rule.ts
@@ -37,10 +37,7 @@ export class CheckPullRequestsRule extends Rule {
     ruleConfig: CheckPullRequestsRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     this.googleAnalytics
       .event('Rule', 'checkPullRequests', webhook.getCloneURL())
       .send();

--- a/src/rules/checkPullRequests.rule.ts
+++ b/src/rules/checkPullRequests.rule.ts
@@ -78,11 +78,7 @@ export class CheckPullRequestsRule extends Rule {
     ruleResult.validated = PRToUpdate.length > 0;
 
     if (ruleResult.validated) {
-      ruleResult.data = {
-        pullRequest: { number: PRToUpdate },
-      };
-    } else {
-      ruleResult.data = {};
+      ruleResult.data.pullRequest.number = PRToUpdate;
     }
 
     return ruleResult;

--- a/src/rules/checkVulnerabilities.rule.spec.ts
+++ b/src/rules/checkVulnerabilities.rule.spec.ts
@@ -96,7 +96,7 @@ describe('RulesService', () => {
 
       expect(download).toBeCalledTimes(2);
       expect(result.validated).toBe(true);
-      expect(result.data).toEqual({ vulnerabilities: {} });
+      expect(result.data.vulnerabilities).toEqual({});
     });
   });
 

--- a/src/rules/checkVulnerabilities.rule.ts
+++ b/src/rules/checkVulnerabilities.rule.ts
@@ -45,10 +45,7 @@ export class CheckVulnerabilitiesRule extends Rule {
     ruleConfig: CheckVulnerabilitiesRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     this.googleAnalytics
       .event('Rule', 'checkVulnerabilities', webhook.getCloneURL())
       .send();

--- a/src/rules/checkVulnerabilities.rule.ts
+++ b/src/rules/checkVulnerabilities.rule.ts
@@ -89,16 +89,12 @@ export class CheckVulnerabilitiesRule extends Rule {
         `cd packages/${webhook.getRemoteDirectory()} & npm audit --json`,
       );
 
-      ruleResult.data = {
-        vulnerabilities: JSON.parse(audit.stdout),
-      };
+      ruleResult.data.vulnerabilities = JSON.parse(audit.stdout);
       ruleResult.validated = true;
     } catch (e) {
       const data = JSON.parse(e.stdout);
-      ruleResult.data = {
-        number: this.getNumberOfVulnerabilities(data),
-        vulnerabilities: JSON.stringify(data),
-      };
+      ruleResult.data.number = this.getNumberOfVulnerabilities(data);
+      ruleResult.data.vulnerabilities = JSON.stringify(data);
       ruleResult.validated = false;
     }
 

--- a/src/rules/commitMessage.rule.spec.ts
+++ b/src/rules/commitMessage.rule.spec.ts
@@ -78,34 +78,31 @@ describe('RulesService', () => {
         webhook,
         commitMessage,
       );
-      const expectedResult = {
-        branch: 'test_webhook',
-        commits: [
-          {
-            status: 'Success',
-            success: true,
-            sha: '1',
-            message: 'fix: readme (#12)',
-            matches: ['fix: readme (#12)', 'fix', null, '(#12)'],
-          },
-          {
-            status: 'Success',
-            success: true,
-            sha: '2',
-            message: 'feat(test): tdd (#34)',
-            matches: ['feat(test): tdd (#34)', 'feat', '(test)', '(#34)'],
-          },
-          {
-            status: 'Success',
-            success: true,
-            sha: '3',
-            message: 'docs: gh-pages',
-            matches: ['docs: gh-pages', 'docs', null, null],
-          },
-        ],
-      };
+      const expectedResult = [
+        {
+          status: 'Success',
+          success: true,
+          sha: '1',
+          message: 'fix: readme (#12)',
+          matches: ['fix: readme (#12)', 'fix', null, '(#12)'],
+        },
+        {
+          status: 'Success',
+          success: true,
+          sha: '2',
+          message: 'feat(test): tdd (#34)',
+          matches: ['feat(test): tdd (#34)', 'feat', '(test)', '(#34)'],
+        },
+        {
+          status: 'Success',
+          success: true,
+          sha: '3',
+          message: 'docs: gh-pages',
+          matches: ['docs: gh-pages', 'docs', null, null],
+        },
+      ];
       expect(result.validated).toBe(true);
-      expect(JSON.stringify(result.data)).toEqual(
+      expect(JSON.stringify(result.data.commits)).toEqual(
         JSON.stringify(expectedResult),
       ); // JSON.stringify needed : https://github.com/facebook/jest/issues/5998
     });

--- a/src/rules/commitMessage.rule.ts
+++ b/src/rules/commitMessage.rule.ts
@@ -46,10 +46,7 @@ export class CommitMessageRule extends Rule {
     ruleConfig: CommitMessageRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     const commits: WebhookCommit[] = webhook.getAllCommits();
     if (commits.length === 0) {
       return null;

--- a/src/rules/commitMessage.rule.ts
+++ b/src/rules/commitMessage.rule.ts
@@ -100,10 +100,7 @@ export class CommitMessageRule extends Rule {
     });
 
     ruleResult.validated = allRegExpSuccessed;
-    ruleResult.data = {
-      branch: webhook.getBranchName(),
-      commits: commitsMatches,
-    };
+    ruleResult.data.commits = commitsMatches;
 
     return ruleResult;
   }

--- a/src/rules/issueComment.rule.spec.ts
+++ b/src/rules/issueComment.rule.spec.ts
@@ -60,18 +60,6 @@ describe('RulesService', () => {
         issueComment,
       );
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual({
-        comment: {
-          description: 'comment on issue',
-          id: 123,
-          matches: null,
-        },
-        issue: {
-          description: 'issue description',
-          number: 22,
-          title: 'my issue for webhook',
-        },
-      });
     });
 
     it('should return true', async () => {
@@ -81,18 +69,7 @@ describe('RulesService', () => {
         issueComment,
       );
       expect(result.validated).toBe(true);
-      expect(JSON.parse(JSON.stringify(result.data))).toEqual({
-        comment: {
-          description: '@ping',
-          id: 123,
-          matches: ['@ping'],
-        },
-        issue: {
-          description: 'issue description',
-          number: 22,
-          title: 'my issue for webhook',
-        },
-      });
+      expect(JSON.stringify(result.data.comment.matches)).toEqual(JSON.stringify(['@ping']));
     });
   });
 });

--- a/src/rules/issueComment.rule.spec.ts
+++ b/src/rules/issueComment.rule.spec.ts
@@ -69,7 +69,9 @@ describe('RulesService', () => {
         issueComment,
       );
       expect(result.validated).toBe(true);
-      expect(JSON.stringify(result.data.comment.matches)).toEqual(JSON.stringify(['@ping']));
+      expect(JSON.stringify(result.data.comment.matches)).toEqual(
+        JSON.stringify(['@ping']),
+      );
     });
   });
 });

--- a/src/rules/issueComment.rule.ts
+++ b/src/rules/issueComment.rule.ts
@@ -34,10 +34,7 @@ export class IssueCommentRule extends Rule {
     ruleConfig: IssueCommentRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     const commentDescription = webhook.getCommentDescription();
     const commentRegExp = RegExp(ruleConfig.options.regexp);
 

--- a/src/rules/issueComment.rule.ts
+++ b/src/rules/issueComment.rule.ts
@@ -48,19 +48,8 @@ export class IssueCommentRule extends Rule {
     }
 
     ruleResult.validated = commentRegExp.test(commentDescription);
+    ruleResult.data.comment.matches = commentDescription.match(commentRegExp);
 
-    ruleResult.data = {
-      issue: {
-        title: webhook.getIssueTitle(),
-        number: webhook.getIssueNumber(),
-        description: webhook.getIssueDescription(),
-      },
-      comment: {
-        id: webhook.getCommentId(),
-        description: commentDescription,
-        matches: commentDescription.match(commentRegExp),
-      },
-    };
     return ruleResult;
   }
 }

--- a/src/rules/issueTitle.rule.spec.ts
+++ b/src/rules/issueTitle.rule.spec.ts
@@ -64,7 +64,9 @@ describe('RulesService', () => {
       const result: RuleResult = await issueTitle.validate(webhook, issueTitle);
 
       expect(result.validated).toBe(true);
-      expect(JSON.stringify(result.data.issue.matches)).toEqual(JSON.stringify(['add rules documentation', 'add']));
+      expect(JSON.stringify(result.data.issue.matches)).toEqual(
+        JSON.stringify(['add rules documentation', 'add']),
+      );
       expect(result.gitApiInfos).toEqual({
         git: 'Github',
         repositoryFullName: 'bastienterrier/test_webhook',

--- a/src/rules/issueTitle.rule.spec.ts
+++ b/src/rules/issueTitle.rule.spec.ts
@@ -62,16 +62,9 @@ describe('RulesService', () => {
       jest.spyOn(issueTitle, 'validate');
 
       const result: RuleResult = await issueTitle.validate(webhook, issueTitle);
-      const expectedResult = {
-        issue: {
-          matches: ['add rules documentation', 'add'],
-          number: 22,
-          title: 'add rules documentation',
-          description: 'please consider adding a Rules section',
-        },
-      };
+
       expect(result.validated).toBe(true);
-      expect(JSON.parse(JSON.stringify(result.data))).toEqual(expectedResult);
+      expect(JSON.stringify(result.data.issue.matches)).toEqual(JSON.stringify(['add rules documentation', 'add']));
       expect(result.gitApiInfos).toEqual({
         git: 'Github',
         repositoryFullName: 'bastienterrier/test_webhook',
@@ -92,16 +85,10 @@ describe('RulesService', () => {
       jest.spyOn(issueTitle, 'validate');
 
       const result: RuleResult = await issueTitle.validate(webhook, issueTitle);
-      const expectedResult = {
-        issue: {
-          description: 'please consider adding a Rules section',
-          matches: null,
-          number: 22,
-          title: 'update rules documentation',
-        },
-      };
+
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual(expectedResult);
+      expect(result.data.issue.matches).toEqual(null);
+
       expect(result.gitApiInfos).toEqual({
         git: 'Gitlab',
         projectId: '7657',

--- a/src/rules/issueTitle.rule.ts
+++ b/src/rules/issueTitle.rule.ts
@@ -34,10 +34,7 @@ export class IssueTitleRule extends Rule {
     ruleConfig: IssueTitleRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     const titleIssue = webhook.getIssueTitle();
     const issueRegExp = RegExp(ruleConfig.options.regexp);
 

--- a/src/rules/issueTitle.rule.ts
+++ b/src/rules/issueTitle.rule.ts
@@ -48,15 +48,8 @@ export class IssueTitleRule extends Rule {
     }
 
     ruleResult.validated = issueRegExp.test(titleIssue);
+    ruleResult.data.issue.matches = titleIssue.match(issueRegExp);
 
-    ruleResult.data = {
-      issue: {
-        title: titleIssue,
-        number: webhook.getIssueNumber(),
-        description: webhook.getIssueDescription(),
-        matches: titleIssue.match(issueRegExp),
-      },
-    };
     return ruleResult;
   }
 }

--- a/src/rules/oneCommitPerPR.rule.spec.ts
+++ b/src/rules/oneCommitPerPR.rule.spec.ts
@@ -61,8 +61,7 @@ describe('RulesService', () => {
         oneCommitPerPR,
       );
       expect(result.validated).toBe(false);
-      expect((result.data as any).commits).toEqual(webhook.commits);
-      expect((result.data as any).branch).toEqual(webhook.branchName);
+      expect(result.data.commits).toEqual(webhook.commits);
     });
   });
   describe('oneCommitPerPR Rule', () => {
@@ -83,8 +82,7 @@ describe('RulesService', () => {
         oneCommitPerPR,
       );
       expect(result.validated).toBe(true);
-      expect((result.data as any).commits).toEqual(webhook.commits);
-      expect((result.data as any).branch).toEqual(webhook.branchName);
+      expect(result.data.commits).toEqual(webhook.commits);
     });
   });
 });

--- a/src/rules/oneCommitPerPR.rule.ts
+++ b/src/rules/oneCommitPerPR.rule.ts
@@ -47,10 +47,6 @@ export class OneCommitPerPRRule extends Rule {
     }
 
     ruleResult.validated = webhook.getAllCommits().length === 1 ? true : false;
-    ruleResult.data = {
-      branch: webhook.getBranchName(),
-      commits: webhook.getAllCommits(),
-    };
     return ruleResult;
   }
 }

--- a/src/rules/oneCommitPerPR.rule.ts
+++ b/src/rules/oneCommitPerPR.rule.ts
@@ -33,10 +33,7 @@ export class OneCommitPerPRRule extends Rule {
     ruleConfig: OneCommitPerPRRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     this.googleAnalytics
       .event('Rule', 'oneCommitPerPR', webhook.getCloneURL())
       .send();

--- a/src/rules/pullRequestComment.rule.spec.ts
+++ b/src/rules/pullRequestComment.rule.spec.ts
@@ -70,7 +70,9 @@ describe('RulesService', () => {
         pullRequestComment,
       );
       expect(result.validated).toBe(true);
-      expect(JSON.parse(JSON.stringify(result.data.comment.matches))).toEqual(['@pong']);
+      expect(JSON.parse(JSON.stringify(result.data.comment.matches))).toEqual([
+        '@pong',
+      ]);
     });
   });
 });

--- a/src/rules/pullRequestComment.rule.spec.ts
+++ b/src/rules/pullRequestComment.rule.spec.ts
@@ -60,18 +60,7 @@ describe('RulesService', () => {
         pullRequestComment,
       );
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual({
-        pullRequest: {
-          title: webhook.pullRequest.title,
-          number: webhook.pullRequest.number,
-          description: webhook.pullRequest.description,
-        },
-        comment: {
-          id: webhook.comment.id,
-          description: webhook.comment.description,
-          matches: null,
-        },
-      });
+      expect(result.data.comment.matches).toEqual(null);
     });
 
     it('should return true', async () => {
@@ -81,18 +70,7 @@ describe('RulesService', () => {
         pullRequestComment,
       );
       expect(result.validated).toBe(true);
-      expect(JSON.parse(JSON.stringify(result.data))).toEqual({
-        pullRequest: {
-          title: webhook.pullRequest.title,
-          number: webhook.pullRequest.number,
-          description: webhook.pullRequest.description,
-        },
-        comment: {
-          id: webhook.comment.id,
-          description: webhook.comment.description,
-          matches: ['@pong'],
-        },
-      });
+      expect(JSON.parse(JSON.stringify(result.data.comment.matches))).toEqual(['@pong']);
     });
   });
 });

--- a/src/rules/pullRequestComment.rule.ts
+++ b/src/rules/pullRequestComment.rule.ts
@@ -47,18 +47,7 @@ export class PullRequestCommentRule extends Rule {
     const commentRegExp = RegExp(ruleConfig.options.regexp);
     ruleResult.validated = commentRegExp.test(commentDescription);
 
-    ruleResult.data = {
-      pullRequest: {
-        title: webhook.getPullRequestTitle(),
-        number: webhook.getPullRequestNumber(),
-        description: webhook.getPullRequestDescription(),
-      },
-      comment: {
-        id: webhook.getCommentId(),
-        description: commentDescription,
-        matches: commentDescription.match(commentRegExp),
-      },
-    };
+    ruleResult.data.comment.matches = commentDescription.match(commentRegExp);
 
     return ruleResult;
   }

--- a/src/rules/pullRequestComment.rule.ts
+++ b/src/rules/pullRequestComment.rule.ts
@@ -33,10 +33,7 @@ export class PullRequestCommentRule extends Rule {
     webhook: Webhook,
     ruleConfig: PullRequestCommentRule,
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     this.googleAnalytics
       .event('Rule', 'pullRequestComment', webhook.getCloneURL())
       .send();

--- a/src/rules/pullRequestTitle.rule.spec.ts
+++ b/src/rules/pullRequestTitle.rule.spec.ts
@@ -80,7 +80,9 @@ describe('RulesService', () => {
         pullRequestTitle,
       );
       expect(result.validated).toBe(true);
-      expect(JSON.parse(JSON.stringify(result.data.pullRequest.matches))).toEqual(['WIP: webhook', 'WIP']);
+      expect(
+        JSON.parse(JSON.stringify(result.data.pullRequest.matches)),
+      ).toEqual(['WIP: webhook', 'WIP']);
     });
   });
 });

--- a/src/rules/pullRequestTitle.rule.spec.ts
+++ b/src/rules/pullRequestTitle.rule.spec.ts
@@ -56,14 +56,7 @@ describe('RulesService', () => {
         pullRequestTitle,
       );
       expect(result.validated).toBe(false);
-      expect(result.data).toEqual({
-        pullRequest: {
-          title: webhook.pullRequest.title,
-          number: webhook.pullRequest.number,
-          description: webhook.pullRequest.description,
-          matches: null,
-        },
-      });
+      expect(result.data.pullRequest.matches).toEqual(null);
     });
   });
   describe('pullRequestTitle Rule', () => {
@@ -87,14 +80,7 @@ describe('RulesService', () => {
         pullRequestTitle,
       );
       expect(result.validated).toBe(true);
-      expect(JSON.parse(JSON.stringify(result.data))).toEqual({
-        pullRequest: {
-          title: webhook.pullRequest.title,
-          number: webhook.pullRequest.number,
-          description: webhook.pullRequest.description,
-          matches: ['WIP: webhook', 'WIP'],
-        },
-      });
+      expect(JSON.parse(JSON.stringify(result.data.pullRequest.matches))).toEqual(['WIP: webhook', 'WIP']);
     });
   });
 });

--- a/src/rules/pullRequestTitle.rule.ts
+++ b/src/rules/pullRequestTitle.rule.ts
@@ -34,10 +34,7 @@ export class PullRequestTitleRule extends Rule {
     ruleConfig: PullRequestTitleRule,
     ruleResults?: RuleResult[],
   ): Promise<RuleResult> {
-    const ruleResult: RuleResult = new RuleResult(
-      webhook.getGitApiInfos(),
-      webhook.getCloneURL(),
-    );
+    const ruleResult: RuleResult = new RuleResult(webhook);
     this.googleAnalytics
       .event('Rule', 'pullRequestTitle', webhook.getCloneURL())
       .send();

--- a/src/rules/pullRequestTitle.rule.ts
+++ b/src/rules/pullRequestTitle.rule.ts
@@ -48,7 +48,9 @@ export class PullRequestTitleRule extends Rule {
     const pullRequestRegExp = RegExp(ruleConfig.options.regexp);
 
     ruleResult.validated = pullRequestRegExp.test(titlePullRequest);
-    ruleResult.data.pullRequest.matches = titlePullRequest.match(pullRequestRegExp);
+    ruleResult.data.pullRequest.matches = titlePullRequest.match(
+      pullRequestRegExp,
+    );
 
     return ruleResult;
   }

--- a/src/rules/pullRequestTitle.rule.ts
+++ b/src/rules/pullRequestTitle.rule.ts
@@ -46,16 +46,10 @@ export class PullRequestTitleRule extends Rule {
 
     const titlePullRequest = webhook.getPullRequestTitle();
     const pullRequestRegExp = RegExp(ruleConfig.options.regexp);
-    ruleResult.validated = pullRequestRegExp.test(titlePullRequest);
 
-    ruleResult.data = {
-      pullRequest: {
-        title: titlePullRequest,
-        number: webhook.getPullRequestNumber(),
-        description: webhook.getPullRequestDescription(),
-        matches: titlePullRequest.match(pullRequestRegExp),
-      },
-    };
+    ruleResult.validated = pullRequestRegExp.test(titlePullRequest);
+    ruleResult.data.pullRequest.matches = titlePullRequest.match(pullRequestRegExp);
+
     return ruleResult;
   }
 }

--- a/src/rules/ruleResult.ts
+++ b/src/rules/ruleResult.ts
@@ -1,4 +1,5 @@
 import { GitApiInfos } from '../git/gitApiInfos';
+import { Webhook } from '../webhook/webhook';
 
 /**
  * Contains the result of the rule `validate()` method.
@@ -11,7 +12,7 @@ export class RuleResult {
   /**
    * Contains meta-data that can be used by `Runnable` (in the `args` object)
    */
-  data: object;
+  data: any;
   /**
    * Provide informations to `Runnable` to interact with Git API
    */
@@ -26,8 +27,9 @@ export class RuleResult {
    */
   env: object;
 
-  constructor(gitApiInfos: GitApiInfos, url: string = '') {
-    this.gitApiInfos = gitApiInfos;
-    this.projectURL = url;
+  constructor(webhook: Webhook) {
+    this.gitApiInfos = webhook.getGitApiInfos();
+    this.projectURL = webhook.getCloneURL();
+    this.data = webhook;
   }
 }

--- a/src/rules/rules.service.ts
+++ b/src/rules/rules.service.ts
@@ -165,9 +165,7 @@ export class RulesService {
           // If all rules have been tested, we can execute runnable functions with the result of previous rules
           if (rulesOptions.allRuleResultInOne) {
             if (groupResults.length > 0) {
-              const ruleResult: RuleResult = new RuleResult(
-                webhook.getGitApiInfos(),
-              );
+              const ruleResult: RuleResult = new RuleResult(webhook);
               ruleResult.data = groupResults;
               this.runnableService
                 .executeRunnableFunctions(ruleResult, g)

--- a/src/runnables/commentIssue.runnable.spec.ts
+++ b/src/runnables/commentIssue.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { CommentIssueRunnable } from './commentIssue.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('CommentIssueRunnable', () => {
   let app: TestingModule;
@@ -40,18 +40,14 @@ describe('CommentIssueRunnable', () => {
     gitlabService = app.get(GitlabService);
     commentIssueRunnable = app.get(CommentIssueRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.issue.number = 22;
 
     args = { comment: 'ping @bastienterrier' };
 
     // ruleResultIssueTitle initialisation
-    ruleResultIssueTitle = new RuleResult(myGitApiInfos);
+    ruleResultIssueTitle = new RuleResult(webhook);
     ruleResultIssueTitle.validated = true;
-    ruleResultIssueTitle.data = {
-      issue: { number: 22 },
-    };
   });
 
   beforeEach(() => {
@@ -74,7 +70,7 @@ describe('CommentIssueRunnable', () => {
         .run(CallbackType.Both, ruleResultIssueTitle, args)
         .catch(err => logger.error(err));
 
-      expect(githubService.addIssueComment).toBeCalled();
+      expect(githubService.addIssueComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
       expect(gitlabService.addIssueComment).not.toBeCalled();
     });
   });
@@ -86,7 +82,7 @@ describe('CommentIssueRunnable', () => {
         .catch(err => logger.error(err));
 
       expect(githubService.addIssueComment).not.toBeCalled();
-      expect(gitlabService.addIssueComment).toBeCalled();
+      expect(gitlabService.addIssueComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
     });
   });
 });

--- a/src/runnables/commentIssue.runnable.spec.ts
+++ b/src/runnables/commentIssue.runnable.spec.ts
@@ -70,7 +70,10 @@ describe('CommentIssueRunnable', () => {
         .run(CallbackType.Both, ruleResultIssueTitle, args)
         .catch(err => logger.error(err));
 
-      expect(githubService.addIssueComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
+      expect(githubService.addIssueComment).toBeCalledWith({
+        comment: 'ping @bastienterrier',
+        number: 22,
+      });
       expect(gitlabService.addIssueComment).not.toBeCalled();
     });
   });
@@ -82,7 +85,10 @@ describe('CommentIssueRunnable', () => {
         .catch(err => logger.error(err));
 
       expect(githubService.addIssueComment).not.toBeCalled();
-      expect(gitlabService.addIssueComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
+      expect(gitlabService.addIssueComment).toBeCalledWith({
+        comment: 'ping @bastienterrier',
+        number: 22,
+      });
     });
   });
 });

--- a/src/runnables/commentPullRequest.runnable.spec.ts
+++ b/src/runnables/commentPullRequest.runnable.spec.ts
@@ -48,7 +48,6 @@ describe('CommentPullRequestRunnable', () => {
     // ruleResultPullRequestTitle initialisation
     ruleResultPullRequestTitle = new RuleResult(webhook);
     ruleResultPullRequestTitle.validated = true;
-
   });
 
   beforeEach(() => {
@@ -72,7 +71,10 @@ describe('CommentPullRequestRunnable', () => {
       commentPullRequestRunnable
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
-      expect(githubService.addPRComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
+      expect(githubService.addPRComment).toBeCalledWith({
+        comment: 'ping @bastienterrier',
+        number: 22,
+      });
       expect(gitlabService.addPRComment).not.toBeCalled();
     });
   });
@@ -83,7 +85,10 @@ describe('CommentPullRequestRunnable', () => {
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
       expect(githubService.addPRComment).not.toBeCalled();
-      expect(gitlabService.addPRComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
+      expect(gitlabService.addPRComment).toBeCalledWith({
+        comment: 'ping @bastienterrier',
+        number: 22,
+      });
     });
   });
 });

--- a/src/runnables/commentPullRequest.runnable.spec.ts
+++ b/src/runnables/commentPullRequest.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { CommentPullRequestRunnable } from './commentPullRequest.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('CommentPullRequestRunnable', () => {
   let app: TestingModule;
@@ -40,22 +40,15 @@ describe('CommentPullRequestRunnable', () => {
     gitlabService = app.get(GitlabService);
     commentPullRequestRunnable = app.get(CommentPullRequestRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
-
     args = { comment: 'ping @bastienterrier' };
 
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.pullRequest.number = 22;
+
     // ruleResultPullRequestTitle initialisation
-    ruleResultPullRequestTitle = new RuleResult(myGitApiInfos);
+    ruleResultPullRequestTitle = new RuleResult(webhook);
     ruleResultPullRequestTitle.validated = true;
-    ruleResultPullRequestTitle.data = {
-      pullRequest: {
-        title: 'WIP: webhook',
-        number: 22,
-        description: 'my desc',
-      },
-    };
+
   });
 
   beforeEach(() => {
@@ -79,7 +72,7 @@ describe('CommentPullRequestRunnable', () => {
       commentPullRequestRunnable
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
-      expect(githubService.addPRComment).toBeCalled();
+      expect(githubService.addPRComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
       expect(gitlabService.addPRComment).not.toBeCalled();
     });
   });
@@ -90,7 +83,7 @@ describe('CommentPullRequestRunnable', () => {
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
       expect(githubService.addPRComment).not.toBeCalled();
-      expect(gitlabService.addPRComment).toBeCalled();
+      expect(gitlabService.addPRComment).toBeCalledWith({comment: 'ping @bastienterrier', number: 22});
     });
   });
 });

--- a/src/runnables/createIssue.runnable.spec.ts
+++ b/src/runnables/createIssue.runnable.spec.ts
@@ -45,7 +45,8 @@ describe('CreateIssueRunnable', () => {
 
     args = {
       title: 'new issue',
-      description: '{{data.branchName}} as a new commit which failed, find why.',
+      description:
+        '{{data.branchName}} as a new commit which failed, find why.',
       labels: ['bug', 'urgent'],
     };
 
@@ -53,28 +54,28 @@ describe('CreateIssueRunnable', () => {
     ruleResultCommitMessage = new RuleResult(webhook);
     ruleResultCommitMessage.validated = true;
     ruleResultCommitMessage.data.commits = [
-        {
-          status: 'Success',
-          success: true,
-          sha: '1',
-          message: 'fix: readme (#12)',
-          matches: ['fix: readme (#12)', 'fix', null, '(#12)'],
-        },
-        {
-          status: 'Success',
-          success: true,
-          sha: '2',
-          message: 'feat(test): tdd (#34)',
-          matches: ['feat(test): tdd (#34)', 'feat', '(test)', '(#34)'],
-        },
-        {
-          status: 'Success',
-          success: true,
-          sha: '3',
-          message: 'docs: gh-pages',
-          matches: ['docs: gh-pages', 'docs', null, null],
-        },
-      ];
+      {
+        status: 'Success',
+        success: true,
+        sha: '1',
+        message: 'fix: readme (#12)',
+        matches: ['fix: readme (#12)', 'fix', null, '(#12)'],
+      },
+      {
+        status: 'Success',
+        success: true,
+        sha: '2',
+        message: 'feat(test): tdd (#34)',
+        matches: ['feat(test): tdd (#34)', 'feat', '(test)', '(#34)'],
+      },
+      {
+        status: 'Success',
+        success: true,
+        sha: '3',
+        message: 'docs: gh-pages',
+        matches: ['docs: gh-pages', 'docs', null, null],
+      },
+    ];
   });
 
   beforeEach(() => {

--- a/src/runnables/createIssue.runnable.spec.ts
+++ b/src/runnables/createIssue.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { CreateIssueRunnable } from './createIssue.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('CreateIssueRunnable', () => {
   let app: TestingModule;
@@ -40,21 +40,19 @@ describe('CreateIssueRunnable', () => {
     gitlabService = app.get(GitlabService);
     createIssueRunnable = app.get(CreateIssueRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.branchName = 'test_webhook';
 
     args = {
       title: 'new issue',
-      description: '{{data.branch}} as a new commit which failed, find why.',
+      description: '{{data.branchName}} as a new commit which failed, find why.',
       labels: ['bug', 'urgent'],
     };
+
     // ruleResultIssueTitle initialisation
-    ruleResultCommitMessage = new RuleResult(myGitApiInfos);
+    ruleResultCommitMessage = new RuleResult(webhook);
     ruleResultCommitMessage.validated = true;
-    ruleResultCommitMessage.data = {
-      branch: 'test_webhook',
-      commits: [
+    ruleResultCommitMessage.data.commits = [
         {
           status: 'Success',
           success: true,
@@ -76,8 +74,7 @@ describe('CreateIssueRunnable', () => {
           message: 'docs: gh-pages',
           matches: ['docs: gh-pages', 'docs', null, null],
         },
-      ],
-    };
+      ];
   });
 
   beforeEach(() => {

--- a/src/runnables/createPullRequest.runnable.ts
+++ b/src/runnables/createPullRequest.runnable.ts
@@ -60,7 +60,7 @@ export class CreatePullRequestRunnable extends Runnable {
       args.description = '';
     }
     if (typeof args.source === 'undefined') {
-      args.source = '{{data.branch}}';
+      args.source = '{{data.branchBranch}}';
     }
     if (typeof args.target === 'undefined') {
       args.target = 'master';

--- a/src/runnables/createRelease.runnable.spec.ts
+++ b/src/runnables/createRelease.runnable.spec.ts
@@ -46,7 +46,6 @@ describe('createRelease Runnable', () => {
 
     ruleResult = new RuleResult(webhook);
     ruleResult.validated = false;
-
   });
 
   beforeEach(() => {
@@ -69,7 +68,7 @@ describe('createRelease Runnable', () => {
       createReleaseRunnable
         .run(CallbackType.Both, ruleResult, args)
         .catch(err => logger.error(err));
-      expect(githubService.createRelease).toBeCalledWith({tag: 'v0.0.1'});
+      expect(githubService.createRelease).toBeCalledWith({ tag: 'v0.0.1' });
       expect(gitlabService.createRelease).not.toBeCalled();
     });
   });
@@ -81,7 +80,7 @@ describe('createRelease Runnable', () => {
         .run(CallbackType.Both, ruleResult, args)
         .catch(err => logger.error(err));
       expect(githubService.createRelease).not.toBeCalled();
-      expect(gitlabService.createRelease).toBeCalledWith({tag: 'v0.0.1'});
+      expect(gitlabService.createRelease).toBeCalledWith({ tag: 'v0.0.1' });
     });
   });
 });

--- a/src/runnables/deleteBranch.runnable.spec.ts
+++ b/src/runnables/deleteBranch.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { DeleteBranchRunnable } from './deleteBranch.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('DeleteBranchRunnable', () => {
   let app: TestingModule;
@@ -40,20 +40,16 @@ describe('DeleteBranchRunnable', () => {
     gitlabService = app.get(GitlabService);
     deleteBranchRunnable = app.get(DeleteBranchRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.branchName = 'test/webhook';
 
     args = {
-      branchName: '{{data.branch}}',
+      branchName: '{{data.branchName}}',
     };
     // ruleResultBranchName initialisation
-    ruleResultBranchName = new RuleResult(myGitApiInfos);
+    ruleResultBranchName = new RuleResult(webhook);
     ruleResultBranchName.validated = false;
-    ruleResultBranchName.data = {
-      branch: 'test/webhook',
-      branchSplit: ['test', 'webhook'],
-    };
+    ruleResultBranchName.data.branchSplit = ['test', 'webhook'];
   });
 
   beforeEach(() => {

--- a/src/runnables/deleteBranch.runnable.ts
+++ b/src/runnables/deleteBranch.runnable.ts
@@ -50,7 +50,7 @@ export class DeleteBranchRunnable extends Runnable {
       typeof args === 'undefined' ||
       (typeof args !== 'undefined' && typeof args.branchName === 'undefined')
     ) {
-      branchName = (ruleResult as any).data.branch;
+      branchName = (ruleResult as any).data.branchBranch;
     } else {
       branchName = Utils.render(args.branchName, ruleResult);
     }

--- a/src/runnables/deleteFiles.runnable.spec.ts
+++ b/src/runnables/deleteFiles.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { DeleteFilesRunnable } from './deleteFiles.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('DeleteFilesRunnable', () => {
   let app: TestingModule;
@@ -40,21 +40,17 @@ describe('DeleteFilesRunnable', () => {
     gitlabService = app.get(GitlabService);
     deleteFilesRunnable = app.get(DeleteFilesRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.branchName = 'test_branch';
 
     args = {
       message: 'delete files',
       files: 'a.exe,b.exe',
     };
     // ruleResultBranchName initialisation
-    ruleResultCheckAddedFiles = new RuleResult(myGitApiInfos);
+    ruleResultCheckAddedFiles = new RuleResult(webhook);
     ruleResultCheckAddedFiles.validated = true;
-    ruleResultCheckAddedFiles.data = {
-      addedFiles: ['toto.exe', 'tata.exe'],
-      branch: 'test_branch',
-    };
+    ruleResultCheckAddedFiles.data.addedFiles = ['toto.exe', 'tata.exe'];
   });
 
   beforeEach(() => {

--- a/src/runnables/deleteFiles.runnable.ts
+++ b/src/runnables/deleteFiles.runnable.ts
@@ -78,8 +78,8 @@ export class DeleteFilesRunnable extends Runnable {
         gitFileInfos.fileBranch = Utils.render(args.branch, ruleResult);
       } else {
         // Default
-        if (typeof (ruleResult as any).data.branch !== 'undefined') {
-          gitFileInfos.fileBranch = (ruleResult as any).data.branch;
+        if (typeof (ruleResult as any).data.branchName !== 'undefined') {
+          gitFileInfos.fileBranch = (ruleResult as any).data.branchName;
         } else {
           gitFileInfos.fileBranch = 'master';
         }

--- a/src/runnables/deployFolder.runnable.spec.ts
+++ b/src/runnables/deployFolder.runnable.spec.ts
@@ -46,7 +46,6 @@ describe('DeployFolderRunnable', () => {
 
     ruleResult = new RuleResult(webhook);
     ruleResult.validated = false;
-
   });
 
   beforeEach(() => {

--- a/src/runnables/deployFolder.runnable.spec.ts
+++ b/src/runnables/deployFolder.runnable.spec.ts
@@ -61,7 +61,7 @@ describe('DeployFolderRunnable', () => {
   });
   describe('Run method', () => {
     it('should call Github methods', async () => {
-      myGitApiInfos.git = GitTypeEnum.Github;
+      ruleResult.gitApiInfos.git = GitTypeEnum.Github;
       await deployFolderRunnable.run(CallbackType.Both, ruleResult, args);
       expect(githubService.getTree).toBeCalledWith('docs', 'develop');
       expect(githubService.getLastCommit).toBeCalledWith('gh-pages');

--- a/src/runnables/deployFolder.runnable.spec.ts
+++ b/src/runnables/deployFolder.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -12,13 +11,13 @@ import {
 } from '../__mocks__/mocks';
 import { DeployFolderRunnable } from './deployFolder.runnable';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('DeployFolderRunnable', () => {
   let app: TestingModule;
 
   let githubService: GithubService;
-
-  let myGitApiInfos;
+  let gitlabService: GitlabService;
 
   let deployFolderRunnable: DeployFolderRunnable;
 
@@ -30,25 +29,24 @@ describe('DeployFolderRunnable', () => {
       providers: [
         DeployFolderRunnable,
         { provide: GithubService, useClass: MockGithubService },
+        { provide: GitlabService, useClass: MockGitlabService },
         { provide: 'GoogleAnalytics', useValue: MockAnalytics },
         EnvVarAccessor,
       ],
     }).compile();
 
     githubService = app.get(GithubService);
+    gitlabService = app.get(GitlabService);
     deployFolderRunnable = app.get(DeployFolderRunnable);
 
-    myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.branchName = 'develop';
 
     args = { folder: 'docs', branch: 'gh-pages' };
 
-    ruleResult = new RuleResult(myGitApiInfos);
+    ruleResult = new RuleResult(webhook);
     ruleResult.validated = false;
-    ruleResult.data = {
-      branch: 'develop',
-    };
+
   });
 
   beforeEach(() => {

--- a/src/runnables/deployFolder.runnable.ts
+++ b/src/runnables/deployFolder.runnable.ts
@@ -41,7 +41,7 @@ export class DeployFolderRunnable extends Runnable {
     ruleResult.env = this.envVarAccessor.getAllEnvVar();
 
     const gitApiInfos: GitApiInfos = ruleResult.gitApiInfos;
-    const sourceBranch: string = (ruleResult.data as any).branch;
+    const sourceBranch: string = (ruleResult.data as any).branchName;
 
     this.googleAnalytics
       .event('Runnable', 'deployFolder', ruleResult.projectURL)

--- a/src/runnables/logger.runnable.spec.ts
+++ b/src/runnables/logger.runnable.spec.ts
@@ -2,15 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CallbackType } from './runnables.service';
 import { logger } from '../logger/logger.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
-import { GitTypeEnum } from '../webhook/utils.enum';
 import { LoggerRunnable } from './logger.runnable';
-import { MockAnalytics } from '../__mocks__/mocks';
+import { MockAnalytics, MockGithubService, MockGitlabService } from '../__mocks__/mocks';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
+import { GithubService } from '../github/github.service';
+import { GitlabService } from '../gitlab/gitlab.service';
 
 describe('LoggerRunnable', () => {
   let app: TestingModule;
   let loggerRunnable: LoggerRunnable;
+
+  let githubService: GithubService;
+  let gitlabService: GitlabService;
 
   let args: any;
   let ruleResultIssueTitle: RuleResult;
@@ -19,6 +23,8 @@ describe('LoggerRunnable', () => {
     app = await Test.createTestingModule({
       providers: [
         LoggerRunnable,
+        { provide: GithubService, useClass: MockGithubService },
+        { provide: GitlabService, useClass: MockGitlabService },
         { provide: 'GoogleAnalytics', useValue: MockAnalytics },
         EnvVarAccessor,
       ],
@@ -28,23 +34,19 @@ describe('LoggerRunnable', () => {
     logger.warn = jest.fn().mockName('logger.warn');
     logger.error = jest.fn().mockName('logger.error');
 
+    githubService = app.get(GithubService);
+    gitlabService = app.get(GitlabService);
     loggerRunnable = app.get(LoggerRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.issue.title = 'test';
+    webhook.issue.number = 22;
 
     args = { message: '{{data.issue.title}} is a correct issue title' };
 
     // ruleResultIssueTitle initialisation
-    ruleResultIssueTitle = new RuleResult(myGitApiInfos);
+    ruleResultIssueTitle = new RuleResult(webhook);
     ruleResultIssueTitle.validated = true;
-    ruleResultIssueTitle.data = {
-      issue: {
-        number: 22,
-        title: 'test',
-      },
-    };
   });
 
   beforeEach(() => {
@@ -57,7 +59,7 @@ describe('LoggerRunnable', () => {
         .run(CallbackType.Both, ruleResultIssueTitle, args)
         .catch(err => logger.error(err));
 
-      expect(logger.info).toBeCalled();
+      expect(logger.info).toBeCalledWith('test is a correct issue title');
       expect(logger.error).not.toBeCalled();
       expect(logger.warn).not.toBeCalled();
     });
@@ -72,7 +74,7 @@ describe('LoggerRunnable', () => {
         .catch(err => logger.error(err));
 
       expect(logger.info).not.toBeCalled();
-      expect(logger.error).toBeCalled();
+      expect(logger.error).toBeCalledWith('test is a correct issue title');
       expect(logger.warn).not.toBeCalled();
     });
   });
@@ -86,7 +88,7 @@ describe('LoggerRunnable', () => {
         .run(CallbackType.Both, ruleResultIssueTitle, args)
         .catch(err => logger.error(err));
 
-      expect(logger.info).toBeCalled();
+      expect(logger.info).toBeCalledWith('test is a correct issue title');
       expect(logger.error).not.toBeCalled();
       expect(logger.warn).not.toBeCalled();
     });

--- a/src/runnables/logger.runnable.spec.ts
+++ b/src/runnables/logger.runnable.spec.ts
@@ -3,7 +3,11 @@ import { CallbackType } from './runnables.service';
 import { logger } from '../logger/logger.service';
 import { RuleResult } from '../rules/ruleResult';
 import { LoggerRunnable } from './logger.runnable';
-import { MockAnalytics, MockGithubService, MockGitlabService } from '../__mocks__/mocks';
+import {
+  MockAnalytics,
+  MockGithubService,
+  MockGitlabService,
+} from '../__mocks__/mocks';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
 import { Webhook } from '../webhook/webhook';
 import { GithubService } from '../github/github.service';

--- a/src/runnables/mergePullRequest.runnable.spec.ts
+++ b/src/runnables/mergePullRequest.runnable.spec.ts
@@ -74,7 +74,11 @@ describe('MergePullRequestRunnable', () => {
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
 
-      expect(githubService.mergePullRequest).toBeCalledWith({commitTitle: 'merging the PR...', method: 'Merge', number: 22});
+      expect(githubService.mergePullRequest).toBeCalledWith({
+        commitTitle: 'merging the PR...',
+        method: 'Merge',
+        number: 22,
+      });
       expect(gitlabService.mergePullRequest).not.toBeCalled();
     });
   });
@@ -86,7 +90,11 @@ describe('MergePullRequestRunnable', () => {
         .catch(err => logger.error(err));
 
       expect(githubService.mergePullRequest).not.toBeCalled();
-      expect(gitlabService.mergePullRequest).toBeCalledWith({commitTitle: 'merging the PR...', method: 'Merge', number: 22});
+      expect(gitlabService.mergePullRequest).toBeCalledWith({
+        commitTitle: 'merging the PR...',
+        method: 'Merge',
+        number: 22,
+      });
     });
   });
 });

--- a/src/runnables/mergePullRequest.runnable.spec.ts
+++ b/src/runnables/mergePullRequest.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { MergePullRequestRunnable } from './mergePullRequest.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('MergePullRequestRunnable', () => {
   let app: TestingModule;
@@ -40,22 +40,16 @@ describe('MergePullRequestRunnable', () => {
     gitlabService = app.get(GitlabService);
     mergePullRequestRunnable = app.get(MergePullRequestRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.pullRequest.title = 'WIP: webhook';
+    webhook.pullRequest.number = 22;
+    webhook.pullRequest.description = 'my desc';
 
     args = { commitTitle: 'merging the PR...' };
 
     // ruleResultPullRequestTitle initialisation
-    ruleResultPullRequestTitle = new RuleResult(myGitApiInfos);
+    ruleResultPullRequestTitle = new RuleResult(webhook);
     ruleResultPullRequestTitle.validated = true;
-    ruleResultPullRequestTitle.data = {
-      pullRequest: {
-        title: 'WIP: webhook',
-        number: 22,
-        description: 'my desc',
-      },
-    };
   });
 
   beforeEach(() => {
@@ -80,7 +74,7 @@ describe('MergePullRequestRunnable', () => {
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
 
-      expect(githubService.mergePullRequest).toBeCalled();
+      expect(githubService.mergePullRequest).toBeCalledWith({commitTitle: 'merging the PR...', method: 'Merge', number: 22});
       expect(gitlabService.mergePullRequest).not.toBeCalled();
     });
   });
@@ -92,7 +86,7 @@ describe('MergePullRequestRunnable', () => {
         .catch(err => logger.error(err));
 
       expect(githubService.mergePullRequest).not.toBeCalled();
-      expect(gitlabService.mergePullRequest).toBeCalled();
+      expect(gitlabService.mergePullRequest).toBeCalledWith({commitTitle: 'merging the PR...', method: 'Merge', number: 22});
     });
   });
 });

--- a/src/runnables/runnables.service.spec.ts
+++ b/src/runnables/runnables.service.spec.ts
@@ -6,7 +6,11 @@ import {
   MockRunnableModule,
   MockRunnable,
 } from '../__mocks__/mock.runnables.module';
-import { MockAnalytics, MockGitlabService, MockGithubService } from '../__mocks__/mocks';
+import {
+  MockAnalytics,
+  MockGitlabService,
+  MockGithubService,
+} from '../__mocks__/mocks';
 import { Webhook } from '../webhook/webhook';
 import { GitlabService } from '../gitlab/gitlab.service';
 import { GithubService } from '../github/github.service';

--- a/src/runnables/updateCommitStatus.runnable.spec.ts
+++ b/src/runnables/updateCommitStatus.runnable.spec.ts
@@ -4,7 +4,6 @@ import { GitlabService } from '../gitlab/gitlab.service';
 import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
 import {
   MockGitlabService,
   MockGithubService,
@@ -13,6 +12,7 @@ import {
 import { UpdateCommitStatusRunnable } from './updateCommitStatus.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';
+import { Webhook } from '../webhook/webhook';
 
 describe('UpdateCommitStatusRunnable', () => {
   let app: TestingModule;
@@ -40,38 +40,34 @@ describe('UpdateCommitStatusRunnable', () => {
     gitlabService = app.get(GitlabService);
     updateCommitStatus = app.get(UpdateCommitStatusRunnable);
 
-    const myGitApiInfos = new GitApiInfos();
-    myGitApiInfos.repositoryFullName = 'bastienterrier/test_webhook';
-    myGitApiInfos.git = GitTypeEnum.Undefined;
+    const webhook = new Webhook(gitlabService, githubService);
+    webhook.branchName = 'test_webhook';
 
-    ruleResultCommitMessage = new RuleResult(myGitApiInfos);
+    ruleResultCommitMessage = new RuleResult(webhook);
     ruleResultCommitMessage.validated = true;
-    ruleResultCommitMessage.data = {
-      branch: 'test_webhook',
-      commits: [
-        {
-          status: 'Success',
-          success: true,
-          sha: '1',
-          message: 'fix: readme (#12)',
-          matches: ['fix: readme (#12)', 'fix', null, '(#12)'],
-        },
-        {
-          status: 'Success',
-          success: true,
-          sha: '2',
-          message: 'feat(test): tdd (#34)',
-          matches: ['feat(test): tdd (#34)', 'feat', '(test)', '(#34)'],
-        },
-        {
-          status: 'Success',
-          success: true,
-          sha: '3',
-          message: 'docs: gh-pages',
-          matches: ['docs: gh-pages', 'docs', null, null],
-        },
-      ],
-    };
+    ruleResultCommitMessage.data.commits = [
+      {
+        status: 'Success',
+        success: true,
+        sha: '1',
+        message: 'fix: readme (#12)',
+        matches: ['fix: readme (#12)', 'fix', null, '(#12)'],
+      },
+      {
+        status: 'Success',
+        success: true,
+        sha: '2',
+        message: 'feat(test): tdd (#34)',
+        matches: ['feat(test): tdd (#34)', 'feat', '(test)', '(#34)'],
+      },
+      {
+        status: 'Success',
+        success: true,
+        sha: '3',
+        message: 'docs: gh-pages',
+        matches: ['docs: gh-pages', 'docs', null, null],
+      },
+    ];
     args = {
       successTargetUrl: 'http://www.google.com',
       failTargetUrl: 'http://moogle.com/',

--- a/src/runnables/updateIssue.runnable.spec.ts
+++ b/src/runnables/updateIssue.runnable.spec.ts
@@ -70,7 +70,10 @@ describe('UpdateIssueRunnable', () => {
         .run(CallbackType.Both, ruleResultIssueTitle, args)
         .catch(err => logger.error(err));
 
-      expect(githubService.updateIssue).toBeCalledWith({number: '22', state: 'Close'});
+      expect(githubService.updateIssue).toBeCalledWith({
+        number: '22',
+        state: 'Close',
+      });
       expect(gitlabService.updateIssue).not.toBeCalled();
     });
   });
@@ -82,7 +85,10 @@ describe('UpdateIssueRunnable', () => {
         .catch(err => logger.error(err));
 
       expect(githubService.updateIssue).not.toBeCalled();
-      expect(gitlabService.updateIssue).toBeCalledWith({number: '22', state: 'Close'});
+      expect(gitlabService.updateIssue).toBeCalledWith({
+        number: '22',
+        state: 'Close',
+      });
     });
   });
 });

--- a/src/runnables/updatePullRequest.runnable.spec.ts
+++ b/src/runnables/updatePullRequest.runnable.spec.ts
@@ -75,7 +75,10 @@ describe('UpdatePullRequestRunnable', () => {
       updatePullRequestRunnable
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
-      expect(githubService.updatePullRequest).toBeCalledWith({number: 22, title: 'Default title'});
+      expect(githubService.updatePullRequest).toBeCalledWith({
+        number: 22,
+        title: 'Default title',
+      });
       expect(gitlabService.updatePullRequest).not.toBeCalled();
     });
   });
@@ -86,7 +89,10 @@ describe('UpdatePullRequestRunnable', () => {
         .run(CallbackType.Both, ruleResultPullRequestTitle, args)
         .catch(err => logger.error(err));
       expect(githubService.updatePullRequest).not.toBeCalled();
-      expect(gitlabService.updatePullRequest).toBeCalledWith({number: 22, title: 'Default title'});
+      expect(gitlabService.updatePullRequest).toBeCalledWith({
+        number: 22,
+        title: 'Default title',
+      });
     });
   });
 });

--- a/src/runnables/webhook.runnable.spec.ts
+++ b/src/runnables/webhook.runnable.spec.ts
@@ -1,10 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpService } from '@nestjs/common';
-import { GitTypeEnum } from '../webhook/utils.enum';
 import { CallbackType } from './runnables.service';
 import { RuleResult } from '../rules/ruleResult';
-import { GitApiInfos } from '../git/gitApiInfos';
-import { MockHttpService, MockAnalytics, MockGitlabService, MockGithubService } from '../__mocks__/mocks';
+import {
+  MockHttpService,
+  MockAnalytics,
+  MockGitlabService,
+  MockGithubService,
+} from '../__mocks__/mocks';
 import { WebhookRunnable } from './webhook.runnable';
 import { logger } from '../logger/logger.service';
 import { EnvVarAccessor } from '../env-var/env-var.accessor';

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -277,7 +277,7 @@ describe('Utils', () => {
           callback: LoggerRunnable
         onSuccess:
         - args:
-            message: 'pattern match: branch: {{data.branch}} {{#data.commits}}{{sha}} =
+            message: 'pattern match: branch: {{data.branchBranch}} {{#data.commits}}{{sha}} =
               {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}'
           callback: LoggerRunnable
         - args:
@@ -366,7 +366,7 @@ describe('Utils', () => {
               {
                 args: {
                   message:
-                    'pattern match: branch: {{data.branch}} {{#data.commits}}{{sha}} = {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}',
+                    'pattern match: branch: {{data.branchBranch}} {{#data.commits}}{{sha}} = {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}',
                 },
                 callback: 'LoggerRunnable',
               },
@@ -414,7 +414,7 @@ describe('Utils', () => {
               {
                 "callback": "LoggerRunnable",
                 "args": {
-                  "message": "pattern match: branch: {{data.branch}} {{#data.commits}}{{sha}} = {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}"
+                  "message": "pattern match: branch: {{data.branchBranch}} {{#data.commits}}{{sha}} = {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}"
                 }
               },
               {
@@ -565,7 +565,7 @@ describe('Utils', () => {
               {
                 args: {
                   message:
-                    'pattern match: branch: {{data.branch}} {{#data.commits}}{{sha}} = {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}',
+                    'pattern match: branch: {{data.branchBranch}} {{#data.commits}}{{sha}} = {{matches.1}} | Scope: {{matches.2}} | Issue: {{matches.3}} {{/data.commits}}',
                 },
                 callback: 'LoggerRunnable',
               },


### PR DESCRIPTION
# Abstract
- `RuleResult` constructor take a `Webhook` object
- `Rules` have been updated to push additional data into `ruleResult.data` if needed
- All tests have been updated
- `data.branch` is replaced by `data.branchName` to fit the `webhook` object